### PR TITLE
Bug/duplicate and exclude batch jobs

### DIFF
--- a/EventEspresso/ruleset.xml
+++ b/EventEspresso/ruleset.xml
@@ -291,6 +291,7 @@
         <exclude-pattern>*\.helper.php</exclude-pattern>
         <exclude-pattern>*\.interface.php</exclude-pattern>
         <exclude-pattern>JobHandlerInterface.php</exclude-pattern>
+        <exclude-pattern>*/batch/JobHandlers/*</exclude-pattern>
         <exclude-pattern>LegacyRequestInterface.php</exclude-pattern>
         <exclude-pattern>EE_Message_Generated_From_Token.php</exclude-pattern>
         <exclude-pattern>EE_Message_To_Generate_From_Queue.php</exclude-pattern>

--- a/EventEspresso/ruleset.xml
+++ b/EventEspresso/ruleset.xml
@@ -193,47 +193,6 @@
         <exclude-pattern>*.model.ext.php</exclude-pattern>
     </rule>
 
-    <rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">
-        <exclude-pattern>brewing_regular.php</exclude-pattern>
-        <exclude-pattern>*_Config.php</exclude-pattern>
-        <exclude-pattern>EE_SPCO_JSON_Response.php</exclude-pattern>
-        <exclude-pattern>*.class.php</exclude-pattern>
-        <exclude-pattern>*.core.php</exclude-pattern>
-        <exclude-pattern>*\.template.php</exclude-pattern>
-        <exclude-pattern>*\.module.php</exclude-pattern>
-        <exclude-pattern>*.lib.php</exclude-pattern>
-        <exclude-pattern>*.help_tab*</exclude-pattern>
-        <exclude-pattern>*\.form.php</exclude-pattern>
-        <exclude-pattern>*\.gateway.php</exclude-pattern>
-        <exclude-pattern>*.pm.php</exclude-pattern>
-        <exclude-pattern>*.dmsstage.php</exclude-pattern>
-        <exclude-pattern>*.dms.php</exclude-pattern>
-        <exclude-pattern>*\.model.php</exclude-pattern>
-        <exclude-pattern>*/db_models/relations/*</exclude-pattern>
-        <exclude-pattern>*/db_models/fields/*</exclude-pattern>
-        <exclude-pattern>*/db_models/helpers/*</exclude-pattern>
-        <exclude-pattern>*\.strategy.php</exclude-pattern>
-        <exclude-pattern>*\.helper.php</exclude-pattern>
-        <exclude-pattern>*\.interface.php</exclude-pattern>
-        <exclude-pattern>EE_Message_Generated_From_Token.php</exclude-pattern>
-        <exclude-pattern>EE_Message_To_Generate_From_Queue.php</exclude-pattern>
-        <exclude-pattern>EE_Message_To_Generate_From_Request.php</exclude-pattern>
-        <exclude-pattern>EE_Message_To_Generate.php</exclude-pattern>
-        <exclude-pattern>*\.error.php</exclude-pattern>
-        <exclude-pattern>*\.input.php</exclude-pattern>
-        <exclude-pattern>EE_Integer_Input.php</exclude-pattern>
-        <exclude-pattern>EE_Button_Input.php</exclude-pattern>
-        <exclude-pattern>EE_Country_Select_Input.php</exclude-pattern>
-        <exclude-pattern>EE_Datepicker_Input.php</exclude-pattern>
-        <exclude-pattern>EE_State_Select_Input.php</exclude-pattern>
-        <exclude-pattern>*\.shortcode.php</exclude-pattern>
-        <exclude-pattern>*\.widget.php</exclude-pattern>
-        <exclude-pattern>*.class_extension.php</exclude-pattern>
-        <exclude-pattern>*.class_ext.php</exclude-pattern>
-        <exclude-pattern>*.model_ext.php</exclude-pattern>
-        <exclude-pattern>*.model.ext.php</exclude-pattern>
-    </rule>
-
     <rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
         <exclude-pattern>*_Config.php</exclude-pattern>
         <exclude-pattern>brewing_regular.php</exclude-pattern>


### PR DESCRIPTION
Removes the duplicate entry for `Squiz.Classes.ValidClassName.NotCamelCaps` rules, and excludes the `batch/JobHandlers` folder from using the `PSR1.Methods.CamelCapsMethodName.NotCamelCaps` sniff which was causing these failures: https://travis-ci.com/eventespresso/event-espresso-core/jobs/272205208